### PR TITLE
Fix typo in threewaymerge module

### DIFF
--- a/lib/threewaymerge.js
+++ b/lib/threewaymerge.js
@@ -81,6 +81,6 @@ var threewaymerge = function(a,b,ancestor) {
   var reduced = reducer(diffA,diffB)
   var conflicts = conflict(reduced)
   var finalset = remover(reduced,conflicts)
-  return {diffA:diffA,diffB,diffB,reduced:reduced,conflicts:conflicts,finalset:finalset}
+  return {diffA:diffA,diffB:diffB,reduced:reduced,conflicts:conflicts,finalset:finalset}
 }
 exports.threewaymerge = threewaymerge


### PR DESCRIPTION
Found it by running the tests on node v.0.12.x. It isn’t breaking for you and in Travis because in latest node, the typo is interpreted as the new [property shorthand syntax](https://github.com/airbnb/javascript#3.6), so it still works (it just winds up defining `diffB: diffB` in the object twice). FWIW, the typo would be caught by ESLint’s [no-dupe-keys rule](http://eslint.org/docs/rules/no-dupe-keys.html).